### PR TITLE
Avoid signing in to Harmonia every time

### DIFF
--- a/lib/harmonia.rb
+++ b/lib/harmonia.rb
@@ -1,11 +1,19 @@
 class Harmonia
   def mark_as_done(email:, password:, task_url:)
     agent = Mechanize.new
-    sign_in_page = agent.get("https://harmonia.io/sign-in")
-    sign_in_page.form_with(action: '/session') do |sign_in_form|
-      sign_in_form['email'] = email
-      sign_in_form['password'] = password
-    end.submit
+    if File.exist?('cookies.yml')
+      agent.cookie_jar.load('cookies.yml')
+    end
+    session_cookie = agent.cookie_jar.dup.find { |c| c.name = "_harmonia-next_session" }
+    session_expired = session_cookie && session_cookie.expires < Time.now
+    if session_cookie.nil? || session_expired
+      sign_in_page = agent.get("https://harmonia.io/sign-in")
+      sign_in_page.form_with(action: '/session') do |sign_in_form|
+        sign_in_form['email'] = email
+        sign_in_form['password'] = password
+      end.submit
+      agent.cookie_jar.save('cookies.yml', session: true)
+    end
     task_page = agent.get(task_url)
     task_page.form_with(action: %r{/done$}).submit
   end


### PR DESCRIPTION
Prior to this we were signing in to Harmonia every time we wanted to mark a task as done. Now we store the session cookie on successful sign-in and re-use it for subsequent requests until it expires.

After successful sign-in, the user is taken to the dashboard page. The GFR dashboard page takes quite a while to load even though we've recently stopped using the (large) GFR calendar iCal feed. By only signing in when we really need to, we should avoid loading the dashboard page and hence hopefully run into fewer `Mechanize::ResponseCodeError` errors.
